### PR TITLE
[DEVOPS-2273] Static subnet support

### DIFF
--- a/az/main.tf
+++ b/az/main.tf
@@ -35,6 +35,18 @@ locals {
   # Handles scenario where an emptry string is passed in for lans_per_az
   lans_per_az_checked = "${var.lans_per_az != "" ? var.lans_per_az : "1"}"
 
+  # Check to see if private static subnets are to be provisioned.
+  statics_enabled_check = "${local.statics_per_az_checked > 0 ? 1 : 0}"
+
+  # Check to see if static CIDRs are being overridden. An empty list causes problems in some of the downstream formualtion.
+  static_cidrs_override_enabled = "${length(var.static_cidrs_override) > 0 && var.static_cidrs_override[0] != "non_empty_list" ? "true" : "false"}"
+
+  # Multiplier to be used in downstream calculation based on the number of static subnets per AZ.
+  statics_multiplier = "${local.statics_per_az_checked >= 0 ? local.statics_per_az_checked : 1}"
+
+  # Handles scenario where an emptry string is passed in for statics_per_az
+  statics_per_az_checked = "${var.statics_per_az != "" ? var.statics_per_az : "0"}"
+
   # Check to see if NAT gateways are to be provisioned
   nat_gateways_enabled_check = "${var.nat_gateways_enabled == "true" ? 1 : 0}"
 
@@ -60,10 +72,10 @@ resource "aws_subnet" "dmz" {
   count = "${local.azs_provisioned_count}"
 
   # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
-  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override,count.index)}" : element(data.aws_availability_zones.available.names,count.index)}"
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
 
   # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
-  cidr_block              = "${local.dmz_cidrs_override_enabled == "true" ? element(var.dmz_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count),count.index)}"
+  cidr_block              = "${local.dmz_cidrs_override_enabled == "true" ? element(var.dmz_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count), count.index)}"
   map_public_ip_on_launch = "${var.enable_dmz_public_ips}"
   vpc_id                  = "${var.vpc_id}"
 
@@ -75,7 +87,7 @@ resource "aws_route_table_association" "rta_dmz" {
   count = "${local.azs_provisioned_count}"
 
   route_table_id = "${var.rt_dmz_id}"
-  subnet_id      = "${element(aws_subnet.dmz.*.id,count.index)}"
+  subnet_id      = "${element(aws_subnet.dmz.*.id, count.index)}"
 }
 
 ### Provisions NATs
@@ -114,20 +126,20 @@ resource "aws_eip" "eip_nat" {
 resource "aws_eip_association" "eip_nat_assoc" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.eips_enabled_check * local.nat_gateways_not_enabled_check}"
 
-  allocation_id = "${element(aws_eip.eip_nat.*.id,count.index)}"
-  instance_id   = "${element(aws_instance.nat.*.id,count.index)}"
+  allocation_id = "${element(aws_eip.eip_nat.*.id, count.index)}"
+  instance_id   = "${element(aws_instance.nat.*.id, count.index)}"
 }
 
 resource "aws_instance" "nat" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.nat_gateways_not_enabled_check}"
 
-  ami                         = "${coalesce(var.nat_ami_override,data.aws_ami.nat_ami.id)}"
+  ami                         = "${coalesce(var.nat_ami_override, data.aws_ami.nat_ami.id)}"
   associate_public_ip_address = true
   instance_type               = "${var.nat_instance_type}"
   key_name                    = "${var.nat_key_name}"
   source_dest_check           = false
-  subnet_id                   = "${element(aws_subnet.dmz.*.id,count.index)}"
-  vpc_security_group_ids      = ["${element(aws_security_group.sg_nat.*.id,count.index)}"]
+  subnet_id                   = "${element(aws_subnet.dmz.*.id, count.index)}"
+  vpc_security_group_ids      = ["${element(aws_security_group.sg_nat.*.id, count.index)}"]
 
   tags {
     application = "${var.stack_item_fullname}"
@@ -152,7 +164,7 @@ resource "aws_security_group" "sg_nat" {
   }
 
   ingress {
-    cidr_blocks = ["${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"]
+    cidr_blocks = ["${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"]
     description = "Ingress from ${var.stack_item_label}-lan-${count.index}"
     from_port   = 0
     protocol    = "-1"
@@ -169,8 +181,8 @@ resource "aws_security_group" "sg_nat" {
 resource "aws_nat_gateway" "nat" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.nat_gateways_enabled_check}"
 
-  allocation_id = "${element(aws_eip.eip_nat.*.id,count.index)}"
-  subnet_id     = "${element(aws_subnet.dmz.*.id,count.index)}"
+  allocation_id = "${element(aws_eip.eip_nat.*.id, count.index)}"
+  subnet_id     = "${element(aws_subnet.dmz.*.id, count.index)}"
 }
 
 ###
@@ -182,10 +194,10 @@ resource "aws_subnet" "lan" {
   count = "${local.azs_provisioned_count * local.lans_multiplier}"
 
   # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
-  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override,count.index)}" : element(data.aws_availability_zones.available.names,count.index)}"
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
 
   # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision multiplied by the number of LAN subnets to provision per AZ. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
-  cidr_block = "${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
+  cidr_block = "${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
   vpc_id     = "${var.vpc_id}"
 
   tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-lan-${count.index}"))}"
@@ -209,6 +221,46 @@ resource "aws_route_table" "rt_lan" {
 resource "aws_route_table_association" "rta_lan" {
   count = "${local.azs_provisioned_count * local.lans_multiplier}"
 
-  route_table_id = "${element(aws_route_table.rt_lan.*.id,count.index)}"
-  subnet_id      = "${element(aws_subnet.lan.*.id,count.index)}"
+  route_table_id = "${element(aws_route_table.rt_lan.*.id, count.index)}"
+  subnet_id      = "${element(aws_subnet.lan.*.id, count.index)}"
 }
+
+
+## Provisions static resources
+
+### Provisions subnet
+resource "aws_subnet" "static" {
+  count = "${local.azs_provisioned_count * local.statics_multiplier}"
+
+  # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
+
+  # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision multiplied by the number of static subnets to provision per AZ. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
+  cidr_block = "${local.static_cidrs_override_enabled == "true" ? element(var.static_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.statics_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
+  vpc_id     = "${var.vpc_id}"
+
+  tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-static-${count.index}"))}"
+}
+
+### Provisions routing table
+resource "aws_route_table" "rt_static" {
+  count = "${local.azs_provisioned_count * local.statics_multiplier}"
+
+  propagating_vgws = ["${compact(var.vgw_ids)}"]
+  vpc_id           = "${var.vpc_id}"
+
+  tags {
+    application = "${var.stack_item_fullname}"
+    managed_by  = "terraform"
+    Name        = "${var.stack_item_label}-static-${count.index}"
+  }
+}
+
+### Associates subnet with routing table
+resource "aws_route_table_association" "rta_static" {
+  count = "${local.azs_provisioned_count * local.statics_multiplier}"
+
+  route_table_id = "${element(aws_route_table.rt_static.*.id, count.index)}"
+  subnet_id      = "${element(aws_subnet.static.*.id, count.index)}"
+}
+

--- a/az/main.tf
+++ b/az/main.tf
@@ -72,10 +72,10 @@ resource "aws_subnet" "dmz" {
   count = "${local.azs_provisioned_count}"
 
   # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
-  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override,count.index)}" : element(data.aws_availability_zones.available.names,count.index)}"
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
 
   # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
-  cidr_block              = "${local.dmz_cidrs_override_enabled == "true" ? element(var.dmz_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count),count.index)}"
+  cidr_block              = "${local.dmz_cidrs_override_enabled == "true" ? element(var.dmz_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count), count.index)}"
   map_public_ip_on_launch = "${var.enable_dmz_public_ips}"
   vpc_id                  = "${var.vpc_id}"
 
@@ -87,7 +87,7 @@ resource "aws_route_table_association" "rta_dmz" {
   count = "${local.azs_provisioned_count}"
 
   route_table_id = "${var.rt_dmz_id}"
-  subnet_id      = "${element(aws_subnet.dmz.*.id,count.index)}"
+  subnet_id      = "${element(aws_subnet.dmz.*.id, count.index)}"
 }
 
 ### Provisions NATs
@@ -126,20 +126,20 @@ resource "aws_eip" "eip_nat" {
 resource "aws_eip_association" "eip_nat_assoc" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.eips_enabled_check * local.nat_gateways_not_enabled_check}"
 
-  allocation_id = "${element(aws_eip.eip_nat.*.id,count.index)}"
-  instance_id   = "${element(aws_instance.nat.*.id,count.index)}"
+  allocation_id = "${element(aws_eip.eip_nat.*.id, count.index)}"
+  instance_id   = "${element(aws_instance.nat.*.id, count.index)}"
 }
 
 resource "aws_instance" "nat" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.nat_gateways_not_enabled_check}"
 
-  ami                         = "${coalesce(var.nat_ami_override,data.aws_ami.nat_ami.id)}"
+  ami                         = "${coalesce(var.nat_ami_override, data.aws_ami.nat_ami.id)}"
   associate_public_ip_address = true
   instance_type               = "${var.nat_instance_type}"
   key_name                    = "${var.nat_key_name}"
   source_dest_check           = false
-  subnet_id                   = "${element(aws_subnet.dmz.*.id,count.index)}"
-  vpc_security_group_ids      = ["${element(aws_security_group.sg_nat.*.id,count.index)}"]
+  subnet_id                   = "${element(aws_subnet.dmz.*.id, count.index)}"
+  vpc_security_group_ids      = ["${element(aws_security_group.sg_nat.*.id, count.index)}"]
 
   tags {
     application = "${var.stack_item_fullname}"
@@ -164,7 +164,7 @@ resource "aws_security_group" "sg_nat" {
   }
 
   ingress {
-    cidr_blocks = ["${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"]
+    cidr_blocks = ["${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"]
     description = "Ingress from ${var.stack_item_label}-lan-${count.index}"
     from_port   = 0
     protocol    = "-1"
@@ -181,8 +181,8 @@ resource "aws_security_group" "sg_nat" {
 resource "aws_nat_gateway" "nat" {
   count = "${local.azs_provisioned_count * local.lans_enabled_check * local.nat_gateways_enabled_check}"
 
-  allocation_id = "${element(aws_eip.eip_nat.*.id,count.index)}"
-  subnet_id     = "${element(aws_subnet.dmz.*.id,count.index)}"
+  allocation_id = "${element(aws_eip.eip_nat.*.id, count.index)}"
+  subnet_id     = "${element(aws_subnet.dmz.*.id, count.index)}"
 }
 
 ###
@@ -194,10 +194,10 @@ resource "aws_subnet" "lan" {
   count = "${local.azs_provisioned_count * local.lans_multiplier}"
 
   # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
-  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override,count.index)}" : element(data.aws_availability_zones.available.names,count.index)}"
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
 
   # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision multiplied by the number of LAN subnets to provision per AZ. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
-  cidr_block = "${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
+  cidr_block = "${local.lan_cidrs_override_enabled == "true" ? element(var.lan_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.lans_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
   vpc_id     = "${var.vpc_id}"
 
   tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-lan-${count.index}"))}"
@@ -221,8 +221,8 @@ resource "aws_route_table" "rt_lan" {
 resource "aws_route_table_association" "rta_lan" {
   count = "${local.azs_provisioned_count * local.lans_multiplier}"
 
-  route_table_id = "${element(aws_route_table.rt_lan.*.id,count.index)}"
-  subnet_id      = "${element(aws_subnet.lan.*.id,count.index)}"
+  route_table_id = "${element(aws_route_table.rt_lan.*.id, count.index)}"
+  subnet_id      = "${element(aws_subnet.lan.*.id, count.index)}"
 }
 
 
@@ -233,10 +233,10 @@ resource "aws_subnet" "static" {
   count = "${local.azs_provisioned_count * local.statics_multiplier}"
 
   # Selects the first N number of AZs available for VPC use in the given region, where N is the requested number of AZs to provision. This order can be overidden by passing in an explicit list of AZ letters to be used.
-  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override,count.index)}" : element(data.aws_availability_zones.available.names,count.index)}"
+  availability_zone = "${local.azs_provisioned_override_enabled == "true" ? "${data.aws_region.current.name}${element(var.azs_provisioned_override, count.index)}" : element(data.aws_availability_zones.available.names, count.index)}"
 
   # Provisions N number of evenly allocated address spaces from the overall VPC CIDR block, where N is the requested number of AZs to provision multiplied by the number of static subnets to provision per AZ. Address space per subnet can be overidden by passing in an explicit list of CIDRs to be used.
-  cidr_block = "${local.static_cidrs_override_enabled == "true" ? element(var.static_cidrs_override,count.index) : cidrsubnet(data.aws_vpc.base.cidr_block,lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.statics_multiplier),count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
+  cidr_block = "${local.static_cidrs_override_enabled == "true" ? element(var.static_cidrs_override, count.index) : cidrsubnet(data.aws_vpc.base.cidr_block, lookup(var.az_cidrsubnet_newbits, local.azs_provisioned_count * local.statics_multiplier), count.index + lookup(var.az_cidrsubnet_offset, local.azs_provisioned_count))}"
   vpc_id     = "${var.vpc_id}"
 
   tags = "${merge(local.default_subnet_tags, var.additional_subnet_tags, map("Name", "${var.stack_item_label}-static-${count.index}"))}"
@@ -260,7 +260,7 @@ resource "aws_route_table" "rt_static" {
 resource "aws_route_table_association" "rta_static" {
   count = "${local.azs_provisioned_count * local.statics_multiplier}"
 
-  route_table_id = "${element(aws_route_table.rt_static.*.id,count.index)}"
-  subnet_id      = "${element(aws_subnet.static.*.id,count.index)}"
+  route_table_id = "${element(aws_route_table.rt_static.*.id, count.index)}"
+  subnet_id      = "${element(aws_subnet.static.*.id, count.index)}"
 }
 

--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -9,10 +9,6 @@ output "dmz_cidrs" {
   value = ["${aws_subnet.dmz.*.cidr_block}"]
 }
 
-output "rt_dmz_ids" {
-  value = ["${aws_route_table.rt_dmz.*.id}"]
-}
-
 
 ## Returns information about lan subnets
 output "lan_ids" {

--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -48,6 +48,6 @@ output "eip_nat_ips" {
 }
 
 output "nat_ids" {
-  value = ["${compact(concat(aws_instance.nat.*.id, aws_nat_gateway.nat.*.id))}"]
+  value = ["${compact(concat(aws_instance.nat.*.id,aws_nat_gateway.nat.*.id))}"]
 }
 

--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -48,6 +48,6 @@ output "eip_nat_ips" {
 }
 
 output "nat_ids" {
-  value = ["${compact(concat(aws_instance.nat.*.id,aws_nat_gateway.nat.*.id))}"]
+  value = ["${compact(concat(aws_instance.nat.*.id, aws_nat_gateway.nat.*.id))}"]
 }
 

--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -1,22 +1,46 @@
 # Output Variables
 
-## Returns Subnet IDs
+## Returns information about dmz subnets
 output "dmz_ids" {
   value = ["${aws_subnet.dmz.*.id}"]
 }
 
-output "lan_ids" {
-  value = ["${aws_subnet.lan.*.id}"]
-}
-
-## Returns Subnet CIDR blocks
 output "dmz_cidrs" {
   value = ["${aws_subnet.dmz.*.cidr_block}"]
+}
+
+output "rt_dmz_ids" {
+  value = ["${aws_route_table.rt_dmz.*.id}"]
+}
+
+
+## Returns information about lan subnets
+output "lan_ids" {
+  value = ["${aws_subnet.lan.*.id}"]
 }
 
 output "lan_cidrs" {
   value = ["${aws_subnet.lan.*.cidr_block}"]
 }
+
+output "rt_lan_ids" {
+  value = ["${aws_route_table.rt_lan.*.id}"]
+}
+
+
+## Returns information about static subnets
+output "static_ids" {
+  value = ["${aws_subnet.static.*.id}"]
+}
+
+output "static_cidrs" {
+  value = ["${aws_subnet.static.*.id}"]
+}
+
+output "rt_static_ids" {
+  value = ["${aws_route_table.rt_static.*.id}"]
+}
+
 
 ## Returns information about the NATs
 output "eip_nat_ids" {
@@ -28,10 +52,6 @@ output "eip_nat_ips" {
 }
 
 output "nat_ids" {
-  value = ["${compact(concat(aws_instance.nat.*.id,aws_nat_gateway.nat.*.id))}"]
+  value = ["${compact(concat(aws_instance.nat.*.id, aws_nat_gateway.nat.*.id))}"]
 }
 
-## Returns the routing table ID
-output "rt_lan_ids" {
-  value = ["${aws_route_table.rt_lan.*.id}"]
-}

--- a/az/variables.tf
+++ b/az/variables.tf
@@ -82,6 +82,18 @@ variable "lans_per_az" {
   default     = "1"
 }
 
+variable "static_cidrs_override" {
+  type        = "list"
+  description = "The CIDR block(s) you want the static subnet(s) to cover."
+  default     = ["non_empty_list"]
+}
+
+variable "statics_per_az" {
+  type        = "string"
+  description = "The number of private static subnets to be provisioned per AZ"
+  default     = "0"
+}
+
 variable "nat_ami_override" {
   type        = "string"
   description = "Custom NAT Amazon machine image"

--- a/dhcp/outputs.tf
+++ b/dhcp/outputs.tf
@@ -1,5 +1,5 @@
 # Output variables
 
 output "dhcp_id" {
-  value = "${join(",", compact(aws_vpc_dhcp_options.dhcp.*.id))}"
+  value = "${join(",",compact(aws_vpc_dhcp_options.dhcp.*.id))}"
 }

--- a/dhcp/outputs.tf
+++ b/dhcp/outputs.tf
@@ -1,5 +1,5 @@
 # Output variables
 
 output "dhcp_id" {
-  value = "${join(",",compact(aws_vpc_dhcp_options.dhcp.*.id))}"
+  value = "${join(",", compact(aws_vpc_dhcp_options.dhcp.*.id))}"
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -69,6 +69,6 @@ resource "aws_route" "lan-to-nat" {
   count = "${var.azs_provisioned * var.lans_per_az}"
 
   destination_cidr_block = "0.0.0.0/0"
-  instance_id            = "${element(module.vpc_az.nat_ids, count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
+  instance_id            = "${element(module.vpc_az.nat_ids,count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -69,6 +69,6 @@ resource "aws_route" "lan-to-nat" {
   count = "${var.azs_provisioned * var.lans_per_az}"
 
   destination_cidr_block = "0.0.0.0/0"
-  instance_id            = "${element(module.vpc_az.nat_ids,count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
+  instance_id            = "${element(module.vpc_az.nat_ids, count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -38,7 +38,7 @@ module "vpc_dhcp" {
 ## Configures ACLs
 resource "aws_network_acl" "acl" {
   vpc_id     = "${module.vpc_base.vpc_id}"
-  subnet_ids = ["${concat(module.vpc_az.lan_ids,module.vpc_az.dmz_ids)}"]
+  subnet_ids = ["${concat(module.vpc_az.lan_ids, module.vpc_az.dmz_ids)}"]
 
   tags {
     application = "${var.stack_item_fullname}"
@@ -66,20 +66,20 @@ module "vpc_az" {
 
   azs_provisioned_override = "${var.azs_provisioned_override}"
 
-  dmz_cidrs_override = ["${cidrsubnet(var.vpc_cidr,3,0)}",
-    "${cidrsubnet(var.vpc_cidr,3,1)}",
-    "${cidrsubnet(var.vpc_cidr,3,2)}",
-    "${cidrsubnet(var.vpc_cidr,3,3)}",
+  dmz_cidrs_override = ["${cidrsubnet(var.vpc_cidr, 3, 0)}",
+    "${cidrsubnet(var.vpc_cidr, 3, 1)}",
+    "${cidrsubnet(var.vpc_cidr, 3, 2)}",
+    "${cidrsubnet(var.vpc_cidr, 3, 3)}",
   ]
 
-  lan_cidrs_override = ["${cidrsubnet(var.vpc_cidr,4,8)}",
-    "${cidrsubnet(var.vpc_cidr,4,9)}",
-    "${cidrsubnet(var.vpc_cidr,4,10)}",
-    "${cidrsubnet(var.vpc_cidr,4,11)}",
-    "${cidrsubnet(var.vpc_cidr,4,12)}",
-    "${cidrsubnet(var.vpc_cidr,4,13)}",
-    "${cidrsubnet(var.vpc_cidr,4,14)}",
-    "${cidrsubnet(var.vpc_cidr,4,15)}",
+  lan_cidrs_override = ["${cidrsubnet(var.vpc_cidr, 4, 8)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 9)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 10)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 11)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 12)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 13)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 14)}",
+    "${cidrsubnet(var.vpc_cidr, 4, 15)}",
   ]
 
   lans_per_az          = "${var.lans_per_az}"
@@ -103,16 +103,16 @@ resource "aws_route" "lan-to-nat-gw" {
   count = "${length(var.azs_provisioned_override) * (length(var.lans_per_az) > 0 ? var.lans_per_az : "1") * signum(var.nat_gateways_enabled == "true" ? "1" : "0")}"
 
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(module.vpc_az.nat_ids,count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
+  nat_gateway_id         = "${element(module.vpc_az.nat_ids, count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
 }
 
 resource "aws_route" "lan-to-nat" {
   count = "${length(var.azs_provisioned_override) * (length(var.lans_per_az) > 0 ? var.lans_per_az : "1") * signum(var.nat_gateways_enabled == "true" ? "0" : "1")}"
 
   destination_cidr_block = "0.0.0.0/0"
-  instance_id            = "${element(module.vpc_az.nat_ids,count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
+  instance_id            = "${element(module.vpc_az.nat_ids, count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
 }
 
 resource "aws_vpc_endpoint" "s3-ep" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -38,7 +38,7 @@ module "vpc_dhcp" {
 ## Configures ACLs
 resource "aws_network_acl" "acl" {
   vpc_id     = "${module.vpc_base.vpc_id}"
-  subnet_ids = ["${concat(module.vpc_az.lan_ids, module.vpc_az.dmz_ids)}"]
+  subnet_ids = ["${concat(module.vpc_az.lan_ids,module.vpc_az.dmz_ids)}"]
 
   tags {
     application = "${var.stack_item_fullname}"
@@ -66,20 +66,20 @@ module "vpc_az" {
 
   azs_provisioned_override = "${var.azs_provisioned_override}"
 
-  dmz_cidrs_override = ["${cidrsubnet(var.vpc_cidr, 3, 0)}",
-    "${cidrsubnet(var.vpc_cidr, 3, 1)}",
-    "${cidrsubnet(var.vpc_cidr, 3, 2)}",
-    "${cidrsubnet(var.vpc_cidr, 3, 3)}",
+  dmz_cidrs_override = ["${cidrsubnet(var.vpc_cidr,3,0)}",
+    "${cidrsubnet(var.vpc_cidr,3,1)}",
+    "${cidrsubnet(var.vpc_cidr,3,2)}",
+    "${cidrsubnet(var.vpc_cidr,3,3)}",
   ]
 
-  lan_cidrs_override = ["${cidrsubnet(var.vpc_cidr, 4, 8)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 9)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 10)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 11)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 12)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 13)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 14)}",
-    "${cidrsubnet(var.vpc_cidr, 4, 15)}",
+  lan_cidrs_override = ["${cidrsubnet(var.vpc_cidr,4,8)}",
+    "${cidrsubnet(var.vpc_cidr,4,9)}",
+    "${cidrsubnet(var.vpc_cidr,4,10)}",
+    "${cidrsubnet(var.vpc_cidr,4,11)}",
+    "${cidrsubnet(var.vpc_cidr,4,12)}",
+    "${cidrsubnet(var.vpc_cidr,4,13)}",
+    "${cidrsubnet(var.vpc_cidr,4,14)}",
+    "${cidrsubnet(var.vpc_cidr,4,15)}",
   ]
 
   lans_per_az          = "${var.lans_per_az}"
@@ -103,16 +103,16 @@ resource "aws_route" "lan-to-nat-gw" {
   count = "${length(var.azs_provisioned_override) * (length(var.lans_per_az) > 0 ? var.lans_per_az : "1") * signum(var.nat_gateways_enabled == "true" ? "1" : "0")}"
 
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(module.vpc_az.nat_ids, count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
+  nat_gateway_id         = "${element(module.vpc_az.nat_ids,count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
 }
 
 resource "aws_route" "lan-to-nat" {
   count = "${length(var.azs_provisioned_override) * (length(var.lans_per_az) > 0 ? var.lans_per_az : "1") * signum(var.nat_gateways_enabled == "true" ? "0" : "1")}"
 
   destination_cidr_block = "0.0.0.0/0"
-  instance_id            = "${element(module.vpc_az.nat_ids, count.index)}"
-  route_table_id         = "${element(module.vpc_az.rt_lan_ids, count.index)}"
+  instance_id            = "${element(module.vpc_az.nat_ids,count.index)}"
+  route_table_id         = "${element(module.vpc_az.rt_lan_ids,count.index)}"
 }
 
 resource "aws_vpc_endpoint" "s3-ep" {

--- a/examples/peering/main.tf
+++ b/examples/peering/main.tf
@@ -27,7 +27,7 @@ resource "aws_route" "requester-to-accepter" {
   count = "${length(var.requester_rt_lan_ids)}"
 
   destination_cidr_block    = "${var.accepter_vpc_cidr}"
-  route_table_id            = "${element(var.requester_rt_lan_ids,count.index)}"
+  route_table_id            = "${element(var.requester_rt_lan_ids, count.index)}"
   vpc_peering_connection_id = "${module.vpc_peer.peer_connection_id}"
 }
 
@@ -35,6 +35,6 @@ resource "aws_route" "accepter-to-requester" {
   count = "${length(var.accepter_rt_lan_ids)}"
 
   destination_cidr_block    = "${var.requester_vpc_cidr}"
-  route_table_id            = "${element(var.accepter_rt_lan_ids,count.index)}"
+  route_table_id            = "${element(var.accepter_rt_lan_ids, count.index)}"
   vpc_peering_connection_id = "${module.vpc_peer.peer_connection_id}"
 }

--- a/examples/peering/main.tf
+++ b/examples/peering/main.tf
@@ -27,7 +27,7 @@ resource "aws_route" "requester-to-accepter" {
   count = "${length(var.requester_rt_lan_ids)}"
 
   destination_cidr_block    = "${var.accepter_vpc_cidr}"
-  route_table_id            = "${element(var.requester_rt_lan_ids, count.index)}"
+  route_table_id            = "${element(var.requester_rt_lan_ids,count.index)}"
   vpc_peering_connection_id = "${module.vpc_peer.peer_connection_id}"
 }
 
@@ -35,6 +35,6 @@ resource "aws_route" "accepter-to-requester" {
   count = "${length(var.accepter_rt_lan_ids)}"
 
   destination_cidr_block    = "${var.requester_vpc_cidr}"
-  route_table_id            = "${element(var.accepter_rt_lan_ids, count.index)}"
+  route_table_id            = "${element(var.accepter_rt_lan_ids,count.index)}"
   vpc_peering_connection_id = "${module.vpc_peer.peer_connection_id}"
 }

--- a/peer/outputs.tf
+++ b/peer/outputs.tf
@@ -1,5 +1,5 @@
 # Outputs
 
 output "peer_connection_id" {
-  value = "${join(",", aws_vpc_peering_connection.peer.*.id)}"
+  value = "${join(",",aws_vpc_peering_connection.peer.*.id)}"
 }

--- a/peer/outputs.tf
+++ b/peer/outputs.tf
@@ -1,5 +1,5 @@
 # Outputs
 
 output "peer_connection_id" {
-  value = "${join(",",aws_vpc_peering_connection.peer.*.id)}"
+  value = "${join(",", aws_vpc_peering_connection.peer.*.id)}"
 }

--- a/vpg/main.tf
+++ b/vpg/main.tf
@@ -22,3 +22,4 @@ resource "aws_vpn_gateway_attachment" "attach" {
   vpc_id         = "${var.vpc_id}"
   vpn_gateway_id = "${aws_vpn_gateway.vpg.id}"
 }
+


### PR DESCRIPTION
Initial support for a set of static subnets to be added optionally to a VPC.

* Defaults to none of these being created.

* Currently generation is a little broken mask size wise. It wasn't immediately important, as we won't be currently using that at all regardless, opting to manually specify the CIDRs for these blocks (since we gave out specific IPs for IOT DNS access.). Plan is to update this PR with the fix for this after getting the main PR up.

To be honest, subnet generation is rather limiting in it's current state. You can only have manually specified subnets or equally distributed public/private networks, you can't specify the number of bits per subnet kind.