### PR TITLE
[DEVOPS-2983]:fix: Conditionally propagate_vgws / syntax fixes

### DIFF
--- a/az/main.tf
+++ b/az/main.tf
@@ -233,7 +233,7 @@ resource "aws_subnet" "lan" {
 resource "aws_route_table" "rt_lan" {
   count = local.azs_provisioned_count * local.lans_multiplier
 
-  propagating_vgws = compact(var.vgw_ids)
+  propagating_vgws = var.propagate_vgws ? compact(var.vgw_ids) : null
   vpc_id           = var.vpc_id
 
   tags = {
@@ -283,7 +283,7 @@ resource "aws_subnet" "static" {
 resource "aws_route_table" "rt_static" {
   count = local.azs_provisioned_count * local.statics_multiplier
 
-  propagating_vgws = compact(var.vgw_ids)
+  propagating_vgws = var.propagate_vgws ? compact(var.vgw_ids) : null
   vpc_id           = var.vpc_id
 
   tags = {

--- a/az/variables.tf
+++ b/az/variables.tf
@@ -84,13 +84,13 @@ variable "lans_per_az" {
 }
 
 variable "static_cidrs_override" {
-  type        = "list"
+  type        = list(string)
   description = "The CIDR block(s) you want the static subnet(s) to cover."
   default     = ["non_empty_list"]
 }
 
 variable "statics_per_az" {
-  type        = "string"
+  type        = string
   description = "The number of private static subnets to be provisioned per AZ"
   default     = "0"
 }
@@ -140,4 +140,8 @@ variable "vpc_id" {
   type        = string
   description = "The ID of the VPC"
 }
-
+variable "propagate_vgws" {
+  type        = bool
+  description = "Whether or not to propagate_vgws in routing tables. In some cases aws_vpn_gateway_route_propagation may be used to manage the propagations."
+  default     = true
+}

--- a/base/main.tf
+++ b/base/main.tf
@@ -42,7 +42,7 @@ resource "aws_internet_gateway" "igw" {
 
 ## Provisions DMZ routing table
 resource "aws_route_table" "rt_dmz" {
-  propagating_vgws = compact(var.vgw_ids)
+  propagating_vgws = var.propagate_vgws ? compact(var.vgw_ids) : null
   vpc_id           = aws_vpc.vpc.id
 
   tags = {

--- a/base/variables.tf
+++ b/base/variables.tf
@@ -77,3 +77,8 @@ variable "vgw_ids" {
   default     = []
 }
 
+variable "propagate_vgws" {
+  type        = bool
+  description = "Whether or not to propagate_vgws in routing tables. In some cases aws_vpn_gateway_route_propagation may be used to manage the propagation."
+  default     = true
+}


### PR DESCRIPTION
* Added a var.propagate_vgws that defaults to true but if false will not set the parameter. This is required if a aws_vpn_gateway_route_propagation resource in a stack is used on the routing table.
* Fixed use of quotes around variable type. This produces a warning in every stack.

Jira: DEVOPS-2983