### PR TITLE
DEVOPS-2026 Output VPC public_ips

### DIFF
--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -50,3 +50,7 @@ output "eip_nat_ips" {
 output "nat_ids" {
   value = compact(concat(aws_instance.nat.*.id, aws_nat_gateway.nat.*.id))
 }
+
+output "nat_public_ips" {
+  value = aws_nat_gateway.nat.*.public_ip
+}


### PR DESCRIPTION
This is the state structure:

```
{
      "module": "module.vpc_az",
      "mode": "managed",
      "type": "aws_nat_gateway",
      "name": "nat",
      "each": "list",
      "provider": "provider.aws",
      "instances": [
        {
          "index_key": 0,
          "schema_version": 0,
          "attributes": {
            "allocation_id": "eipalloc-ed072788",
            "connectivity_type": "public",
            "id": "nat-08fc7a523ae8771ea",
            "network_interface_id": "eni-09bea349",
            "private_ip": "172.16.0.77",
            "public_ip": "52.2.113.161",
            "subnet_id": "subnet-25d0ab52",
            "tags": {},
            "tags_all": {}
          },
          "dependencies": [
            "module.vpc_az.aws_eip.eip_nat",
            "module.vpc_az.aws_subnet.dmz",
            "module.vpc_base.aws_vpc.vpc"
          ]
        },
        {
          "index_key": 1,
          "schema_version": 0,
          "attributes": {
            "allocation_id": "eipalloc-f4072791",
            "connectivity_type": "public",
            "id": "nat-01c40d8890c4a39be",
            "network_interface_id": "eni-d642f285",
            "private_ip": "172.16.0.240",
            "public_ip": "52.2.39.181",
            "subnet_id": "subnet-3241df6b",
            "tags": {},
            "tags_all": {}
          },
....
```
