### PR TITLE
DEVOPS-2036 Add output VPC CIDR Block

### DIFF
--- a/az/outputs.tf
+++ b/az/outputs.tf
@@ -54,3 +54,7 @@ output "nat_ids" {
 output "nat_public_ips" {
   value = aws_nat_gateway.nat.*.public_ip
 }
+
+output "vpc_cidrblock" {
+  value = aws_vpc.base.cidr_block
+}


### PR DESCRIPTION
This is the state structure:

```
{
      "module": "module.vpc_az",
      "mode": "data",
      "type": "aws_vpc",
      "name": "base",
      "provider": "provider.aws",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "arn": "arn:aws:ec2:us-east-1:419697633145:vpc/vpc-0368589e41fdbc393",
            "cidr_block": "172.50.0.0/19",
            "cidr_block_associations": [
              {
                "association_id": "vpc-cidr-assoc-057e3e9b7226a9f05",
                "cidr_block": "172.50.0.0/19",
                "state": "associated"
              }
            ],
            "default": false,
            "dhcp_options_id": "dopt-05ead7a372830db06",
            "enable_dns_hostnames": true,
            "enable_dns_support": true,
            "enable_network_address_usage_metrics": false,
            "filter": null,
            "id": "vpc-0368589e41fdbc393",
            "instance_tenancy": "default",
            "ipv6_association_id": "",
            "ipv6_cidr_block": "",
            "main_route_table_id": "rtb-08012b2f6b74d6614",
            "owner_id": "419697633145",
            "state": null,
            "tags": {
              "Name": "prd-ue1-svcs-vpc",
              "application": "Production Services Environment (N. Virginia)",
              "managed_by": "terraform"
            },
            "timeouts": null
          }
        }
      ]
    },
```
